### PR TITLE
fix an issue unable to open a browser

### DIFF
--- a/raisim_gym/helper/raisim_gym_helper.py
+++ b/raisim_gym/helper/raisim_gym_helper.py
@@ -25,5 +25,4 @@ def TensorboardLauncher(directory_path):
     tb = program.TensorBoard()
     tb.configure(argv=[None, '--logdir', directory_path])
     url = tb.launch()
-    chrome_path = '/usr/bin/google-chrome %s'
-    webbrowser.get(chrome_path).open(url)
+    webbrowser.open_new(url)


### PR DESCRIPTION
This will open the default browser, tested on Ubuntu with Chrome,
Chromium web browser and Firefox.
Please check this before merge.